### PR TITLE
Fix bug with long jump in endless list

### DIFF
--- a/.changeset/honest-snails-destroy.md
+++ b/.changeset/honest-snails-destroy.md
@@ -1,0 +1,5 @@
+---
+'@rchat/react': patch
+---
+
+Fixed bug with long jump in endless list

--- a/packages/react/src/EndlessList/EndlessList.tsx
+++ b/packages/react/src/EndlessList/EndlessList.tsx
@@ -109,9 +109,6 @@ export const EndlessList = <T,>({
 		return smoothScrollToCenter(container, item, jumpAnimation, abortController);
 	});
 
-	const skipScrollToFocusedItem = useRef<boolean>(false);
-	const lastScrolledItem = useRef<T | undefined>();
-
 	const abortControllerReference = useRef<AbortController>();
 	const handleJumpScroll = useCallback(
 		async (abortController = new AbortController()) => {
@@ -147,6 +144,7 @@ export const EndlessList = <T,>({
 	const { observer, visibleItemKeys } = useVisibleItems(containerReference, onVisibleItemsChange);
 	const [scheduleJumpScroll, isJumpScheduled] = useScheduleOnNextRender(handleJumpScroll);
 
+	const lastScrolledItem = useRef<T | undefined>();
 	const handleScrollToFocusItem = useEvent(() => {
 		if (focusedItem === lastScrolledItem.current) {
 			return;
@@ -168,14 +166,11 @@ export const EndlessList = <T,>({
 		handleJump: scheduleJumpScroll,
 		focusedItem,
 		visibleItemKeys,
-		skipScrollToFocusedItem,
 		lastScrolledItem,
 	});
 
 	useEffect(() => {
-		if (!skipScrollToFocusedItem.current) {
-			handleScrollToFocusItem();
-		}
+		handleScrollToFocusItem();
 		hasMounted.current = true;
 	}, [handleScrollToFocusItem, itemsToRender]);
 

--- a/packages/react/src/EndlessList/EndlessList.tsx
+++ b/packages/react/src/EndlessList/EndlessList.tsx
@@ -109,6 +109,9 @@ export const EndlessList = <T,>({
 		return smoothScrollToCenter(container, item, jumpAnimation, abortController);
 	});
 
+	const skipScrollToFocusedItem = useRef<boolean>(false);
+	const lastScrolledItem = useRef<T | undefined>();
+
 	const abortControllerReference = useRef<AbortController>();
 	const handleJumpScroll = useCallback(
 		async (abortController = new AbortController()) => {
@@ -144,7 +147,6 @@ export const EndlessList = <T,>({
 	const { observer, visibleItemKeys } = useVisibleItems(containerReference, onVisibleItemsChange);
 	const [scheduleJumpScroll, isJumpScheduled] = useScheduleOnNextRender(handleJumpScroll);
 
-	const lastScrolledItem = useRef<T | undefined>();
 	const handleScrollToFocusItem = useEvent(() => {
 		if (focusedItem === lastScrolledItem.current) {
 			return;
@@ -166,10 +168,14 @@ export const EndlessList = <T,>({
 		handleJump: scheduleJumpScroll,
 		focusedItem,
 		visibleItemKeys,
+		skipScrollToFocusedItem,
+		lastScrolledItem,
 	});
 
 	useEffect(() => {
-		handleScrollToFocusItem();
+		if (!skipScrollToFocusedItem.current) {
+			handleScrollToFocusItem();
+		}
 		hasMounted.current = true;
 	}, [handleScrollToFocusItem, itemsToRender]);
 

--- a/packages/react/src/EndlessList/useEndlessList.tsx
+++ b/packages/react/src/EndlessList/useEndlessList.tsx
@@ -12,6 +12,8 @@ export type UseEndlessListConfig<T> = {
 	handleJump: (abortController: AbortController) => Promise<void>;
 	focusedItem?: T;
 	visibleItemKeys: MutableRefObject<Set<string>>;
+	skipScrollToFocusedItem: MutableRefObject<boolean>;
+	lastScrolledItem: MutableRefObject<T | undefined>;
 };
 
 export type EndlessListRealItem<TValue> = {
@@ -53,6 +55,8 @@ export const useEndlessList = <T,>({
 	compareItems,
 	handleJump,
 	visibleItemKeys,
+	skipScrollToFocusedItem,
+	lastScrolledItem,
 }: UseEndlessListConfig<T>): Array<EndlessListItem<T>> => {
 	const focusedItemKey = focusedItem === undefined ? undefined : getKey(focusedItem);
 	const defaultConvertItem = useMemo(() => valueToEndlessListItem(getKey, focusedItemKey), [getKey, focusedItemKey]);
@@ -249,6 +253,8 @@ export const useEndlessList = <T,>({
 			constructedItems = oldItems;
 		}
 
+		skipScrollToFocusedItem.current = true;
+
 		setRenderedItems(constructedItems);
 		const newController = new AbortController();
 		jumpAbortController.current = newController;
@@ -257,6 +263,10 @@ export const useEndlessList = <T,>({
 			if (hasMounted.current) {
 				await handleJump(newController);
 			}
+
+			skipScrollToFocusedItem.current = false;
+			lastScrolledItem.current = items[Math.floor(items.length / 2)];
+
 			setRenderedItems(items.map(defaultConvertItem));
 		} catch {
 			/* Noop */

--- a/packages/react/src/EndlessList/useEndlessList.tsx
+++ b/packages/react/src/EndlessList/useEndlessList.tsx
@@ -12,7 +12,6 @@ export type UseEndlessListConfig<T> = {
 	handleJump: (abortController: AbortController) => Promise<void>;
 	focusedItem?: T;
 	visibleItemKeys: MutableRefObject<Set<string>>;
-	skipScrollToFocusedItem: MutableRefObject<boolean>;
 	lastScrolledItem: MutableRefObject<T | undefined>;
 };
 
@@ -55,7 +54,6 @@ export const useEndlessList = <T,>({
 	compareItems,
 	handleJump,
 	visibleItemKeys,
-	skipScrollToFocusedItem,
 	lastScrolledItem,
 }: UseEndlessListConfig<T>): Array<EndlessListItem<T>> => {
 	const focusedItemKey = focusedItem === undefined ? undefined : getKey(focusedItem);
@@ -253,7 +251,7 @@ export const useEndlessList = <T,>({
 			constructedItems = oldItems;
 		}
 
-		skipScrollToFocusedItem.current = true;
+		lastScrolledItem.current = items[Math.floor(items.length / 2)];
 
 		setRenderedItems(constructedItems);
 		const newController = new AbortController();
@@ -263,9 +261,6 @@ export const useEndlessList = <T,>({
 			if (hasMounted.current) {
 				await handleJump(newController);
 			}
-
-			skipScrollToFocusedItem.current = false;
-			lastScrolledItem.current = items[Math.floor(items.length / 2)];
 
 			setRenderedItems(items.map(defaultConvertItem));
 		} catch {

--- a/packages/react/tests/EndlessList/useEndlessList.test.ts
+++ b/packages/react/tests/EndlessList/useEndlessList.test.ts
@@ -32,7 +32,6 @@ const renderEndlessListHook = (initialItems: number[], handleJump?: () => Promis
 				items,
 				initialItems: propsInitialItems ?? initialItems,
 				visibleItemKeys: { current: visibleItemKeys ?? emptySet },
-				skipScrollToFocusedItem: mockRef as unknown as MutableRefObject<boolean>,
 				lastScrolledItem: mockRef as unknown as MutableRefObject<number>,
 			}),
 		{


### PR DESCRIPTION
The problem was that when we search an item, we provide entirely new array of items to endless list. So, it decides to render some placeholders and performs jump animation to the middle of new items. However, the effect that scrolls to the focused item doesn't know that this item has been already scrolled in (`lastScrolledItem` reference doesn't change in EndlessList).

The proposed solution is to set `lastScrolledItem` to middle item of new array when performing "long" jump.